### PR TITLE
Initial support for directory traversal

### DIFF
--- a/minfluxdbconvert/__main__.py
+++ b/minfluxdbconvert/__main__.py
@@ -35,26 +35,27 @@ def main():
     status = False
     try:
         source = config[CONF_MINT][CONF_FILE]
+        LOGGER.debug('Using single file %s', source)
         status = dbwrite.influxdb_write(config, db_client,
                                         source, db_skip=args[ARG_NOPUSH])
     except KeyError:
         source = config[CONF_MINT][CONF_DIR]
+        LOGGER.debug('Using source dir %s', source)
+        status = True
         for file in glob.glob('{}/*.csv'.format(source)):
+            LOGGER.debug('Found %s', file)
             result = dbwrite.influxdb_write(config, db_client,
                                             file, db_skip=args[ARG_NOPUSH])
             if not result:
                 LOGGER.error('Could not write %s to database', file)
-                sys.exit(1)
-        status = True
+                status = False
+                break
 
-    if status:
+    if status and not args[ARG_NOPUSH]:
         LOGGER.info('Databse write successful! :)')
-    else:
+    elif not status:
         LOGGER.error('Database write unsuccessful :(')
         sys.exit(1)
-
-    sys.exit()
-
 
 if __name__ == "__main__":
     main()

--- a/minfluxdbconvert/__main__.py
+++ b/minfluxdbconvert/__main__.py
@@ -1,15 +1,12 @@
 """Primary module for minfluxdb-convert."""
 import sys
-import json
-import os
 import glob
 import logging
 import minfluxdbconvert.util as util
 import minfluxdbconvert.yaml as yaml
 import minfluxdbconvert.dbwrite as dbwrite
-from minfluxdbconvert.const import (CONF_INFLUX, CONF_USER, CONF_PASSWORD, CONF_DBNAME,
-                                    CONF_HOST, CONF_PORT, CONF_FILE, CONF_MINT, CONF_LOGGER,
-                                    CONF_LEVEL, CONF_DIR, CONF_ARCHIVE)
+from minfluxdbconvert.const import (CONF_FILE, CONF_MINT, CONF_LOGGER,
+                                    CONF_LEVEL, CONF_DIR)
 from minfluxdbconvert.const import (ARG_CONFIG, ARG_NOPUSH)
 
 LOGGER = logging.getLogger(__name__)

--- a/minfluxdbconvert/const.py
+++ b/minfluxdbconvert/const.py
@@ -2,7 +2,7 @@
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 0
-PATCH_VERSION = 4
+PATCH_VERSION = 5
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
@@ -29,6 +29,8 @@ CONF_EXCLUDE = 'exclude'
 CONF_VENDOR = 'vendor'
 CONF_CATEGORY = 'category'
 CONF_ACCOUNT = 'account'
+CONF_DIR = 'directory'
+CONF_ARCHIVE = 'archive'
 
 #### ATTRIBUTES ####
 ATTR_DATE = 'date'

--- a/minfluxdbconvert/dbwrite.py
+++ b/minfluxdbconvert/dbwrite.py
@@ -1,0 +1,49 @@
+"""Module that handles writing to database."""
+import os
+import sys
+import logging
+import json
+from influxdb import InfluxDBClient
+from minfluxdbconvert.json import jsonify
+from minfluxdbconvert.const import (CONF_INFLUX, CONF_HOST, CONF_PORT,
+                                    CONF_USER, CONF_PASSWORD, CONF_DBNAME)
+
+LOGGER = logging.getLogger(__name__)
+
+def influxdb_write(config, client, source, db_skip=False):
+    """Reads source data and writes to client."""
+    json_body = jsonify(config, source)
+    if db_skip:
+        LOGGER.warning('Skipping database write.')
+        json_info = json.dumps(json_body)
+        with open('dump.json', 'w') as outfile:
+            json.dump(json_info, outfile)
+        LOGGER.info('Data sent to %s/dump.json', os.getcwd())
+        sys.exit()
+
+    client.write_data(json_body)
+
+    return True
+
+
+class InfluxClient(object):
+    """Wrapper class for influx client."""
+    
+    def __init__(self, config):
+        """Initialize the InfluxDB Client."""
+        self.host = config[CONF_INFLUX][CONF_HOST]
+        self.port = config[CONF_INFLUX][CONF_PORT]
+        self.dbname = config[CONF_INFLUX][CONF_DBNAME]
+        self.user = config[CONF_INFLUX][CONF_USER]
+        self.password = config[CONF_INFLUX][CONF_PASSWORD]
+        self.client = InfluxDBClient(self.host,
+                                     self.port,
+                                     self.user,
+                                     self.password,
+                                     self.dbname
+                                    )
+
+    def write_data(self, data):
+        """Wrapper for influxdb writes."""
+        LOGGER.debug('Writing to %s as %s: %s', self.dbname, self.user, data)
+        self.client.write_points(data)

--- a/minfluxdbconvert/dbwrite.py
+++ b/minfluxdbconvert/dbwrite.py
@@ -1,5 +1,4 @@
 """Module that handles writing to database."""
-import os
 import sys
 import logging
 import json
@@ -16,10 +15,10 @@ def influxdb_write(config, client, source, db_skip=False):
     if db_skip:
         LOGGER.warning('Skipping database write.')
         json_info = json.dumps(json_body)
-        with open('dump.json', 'w') as outfile:
+        with open('{}.json'.format(source), 'w') as outfile:
             json.dump(json_info, outfile)
-        LOGGER.info('Data sent to %s/dump.json', os.getcwd())
-        sys.exit()
+        LOGGER.info('Data sent to %s.json', source)
+        return True
 
     client.write_data(json_body)
 

--- a/minfluxdbconvert/dbwrite.py
+++ b/minfluxdbconvert/dbwrite.py
@@ -1,5 +1,4 @@
 """Module that handles writing to database."""
-import sys
 import logging
 import json
 from influxdb import InfluxDBClient
@@ -27,7 +26,7 @@ def influxdb_write(config, client, source, db_skip=False):
 
 class InfluxClient(object):
     """Wrapper class for influx client."""
-    
+
     def __init__(self, config):
         """Initialize the InfluxDB Client."""
         self.host = config[CONF_INFLUX][CONF_HOST]

--- a/minfluxdbconvert/json.py
+++ b/minfluxdbconvert/json.py
@@ -7,13 +7,24 @@ from minfluxdbconvert.const import (ATTR_DATE, ATTR_DESC, ATTR_LABELS,
                                     ATTR_NOTES, ATTR_ACCOUNT, ATTR_CATEGORY,
                                     ATTR_TYPE, ATTR_AMOUNT)
 from minfluxdbconvert.const import (CONF_NETSUM, CONF_EXCLUDE, CONF_VENDOR,
-                                    CONF_CATEGORY, CONF_ACCOUNT)
+                                    CONF_CATEGORY, CONF_ACCOUNT, CONF_MINT,
+                                    CONF_DIR, CONF_ARCHIVE)
 
 LOGGER = logging.getLogger(__name__)
 
 def jsonify(config, csvfile):
     """Converts csv from mint into json file."""
-    mint = reader.TransactionReader(csvfile)
+    try:
+        arch_config = config[CONF_MINT][CONF_ARCHIVE]
+        arch_dir = None
+        if CONF_DIR in arch_config:
+            arch_dir = arch_config[CONF_DIR]
+        mint = reader.TransactionReader(csvfile,
+                                        archive=True,
+                                        archive_dir=arch_dir)
+    except KeyError:
+        mint = reader.TransactionReader(csvfile)
+
     headers = mint.headers
     json_body = list()
     all_dates = list()

--- a/minfluxdbconvert/reader.py
+++ b/minfluxdbconvert/reader.py
@@ -1,6 +1,10 @@
 """Module used to read csv and report results."""
 import os
+import errno
 import sys
+import pathlib
+import shutil
+import gzip
 import csv
 import logging
 from minfluxdbconvert.const import (ATTR_DATE, ATTR_DESC, ATTR_LABELS, ATTR_NOTES,
@@ -11,13 +15,14 @@ LOGGER = logging.getLogger(__name__)
 class TransactionReader(object):
     """Class to parse transactions."""
 
-    def __init__(self, csvfile):
+    def __init__(self, csvfile, archive=False, archive_dir=None):
         """Initialize class."""
+        self._csvfile = csvfile
         self._data = None
-        if not os.path.isfile(csvfile):
-            LOGGER.error('Invalid file %s', csvfile)
+        if not os.path.isfile(self._csvfile):
+            LOGGER.error('Invalid file %s', self._csvfile)
             sys.exit(1)
-        self.read_csv(csvfile)
+        self.read_csv()
         self._headers = {ATTR_DATE: None,
                          ATTR_DESC: None,
                          ATTR_LABELS: None,
@@ -28,6 +33,8 @@ class TransactionReader(object):
                          ATTR_TYPE: None
                         }
         self.get_headers()
+        if archive:
+            self.archive(archive_dir)
 
     @property
     def headers(self):
@@ -39,10 +46,10 @@ class TransactionReader(object):
         """Returns data read in from csv file."""
         return self._data
 
-    def read_csv(self, csvfile):
+    def read_csv(self):
         """Reads the csv file."""
         data = list()
-        with open(csvfile, newline='') as txfile:
+        with open(self._csvfile, newline='') as txfile:
             txreader = csv.reader(txfile, delimiter=',', quotechar='"')
             for row in txreader:
                 data.append(row)
@@ -60,3 +67,34 @@ class TransactionReader(object):
         LOGGER.debug('Headers: %s', self._headers)
         # Get rid of header line from data
         self._data.pop(0)
+
+    def archive(self, archive_dir):
+        """Used to send csv file to archive."""
+        current_path = pathlib.Path(self._csvfile)
+        if not archive_dir:
+            archive_dir = '{}/archive'.format(current_path.parent)
+        # Creates directory if it does not exist
+        pathlib.Path(archive_dir).mkdir(parents=True, exist_ok=True)
+        file_name_only = current_path.name
+        check_file = '{}/{}.gzip'.format(archive_dir, file_name_only)
+
+        # Make sure there are no name collisions with archive
+        if os.path.exists(check_file):
+            file_name_no_ext = current_path.stem
+            count = 1
+            check_file = '{}/{}_{}.csv.gzip'.format(archive_dir, file_name_no_ext, count)
+            while(os.path.exists(check_file)):
+                count += 1
+                check_file = '{}/{}_{}.csv.gzip'.format(archive_dir,file_name_no_ext, count)
+                if count > 256:
+                    LOGGER.error('Too many name collisions during '
+                                 'archive of %s.  Consider using files '
+                                 'with unique names instead.',
+                                 file_name_no_ext)
+                    sys.exit(1)
+        LOGGER.info('Compressing with gzip to %s', check_file)
+        with gzip.GzipFile(check_file, 'wb') as gzipfile:
+            with open(self._csvfile, 'rb') as input_file:
+                shutil.copyfileobj(input_file, gzipfile)
+        
+        

--- a/minfluxdbconvert/reader.py
+++ b/minfluxdbconvert/reader.py
@@ -1,6 +1,5 @@
 """Module used to read csv and report results."""
 import os
-import errno
 import sys
 import pathlib
 import shutil
@@ -83,9 +82,9 @@ class TransactionReader(object):
             file_name_no_ext = current_path.stem
             count = 1
             check_file = '{}/{}_{}.csv.gzip'.format(archive_dir, file_name_no_ext, count)
-            while(os.path.exists(check_file)):
+            while os.path.exists(check_file):
                 count += 1
-                check_file = '{}/{}_{}.csv.gzip'.format(archive_dir,file_name_no_ext, count)
+                check_file = '{}/{}_{}.csv.gzip'.format(archive_dir, file_name_no_ext, count)
                 if count > 256:
                     LOGGER.error('Too many name collisions during '
                                  'archive of %s.  Consider using files '
@@ -96,5 +95,3 @@ class TransactionReader(object):
         with gzip.GzipFile(check_file, 'wb') as gzipfile:
             with open(self._csvfile, 'rb') as input_file:
                 shutil.copyfileobj(input_file, gzipfile)
-        
-        

--- a/minfluxdbconvert/reader.py
+++ b/minfluxdbconvert/reader.py
@@ -1,5 +1,6 @@
 """Module used to read csv and report results."""
-
+import os
+import sys
 import csv
 import logging
 from minfluxdbconvert.const import (ATTR_DATE, ATTR_DESC, ATTR_LABELS, ATTR_NOTES,
@@ -13,6 +14,9 @@ class TransactionReader(object):
     def __init__(self, csvfile):
         """Initialize class."""
         self._data = None
+        if not os.path.isfile(csvfile):
+            LOGGER.error('Invalid file %s', csvfile)
+            sys.exit(1)
         self.read_csv(csvfile)
         self._headers = {ATTR_DATE: None,
                          ATTR_DESC: None,

--- a/minfluxdbconvert/util.py
+++ b/minfluxdbconvert/util.py
@@ -23,7 +23,7 @@ def date_to_epoch(date):
 def convert_value(value, txtype):
     """Converts value to +/- based on credit/debit transaction type."""
     txtype_map = {'credit': 1, 'debit': -1}
-    LOGGER.debug('Found amount %f of type %s', value, txtype)
+    LOGGER.debug('Found amount %s of type %s', value, txtype)
     return round(txtype_map[txtype] * float(value), 2)
 
 def set_loggers(logger, file=None, level='info'):

--- a/minfluxdbconvert/yaml.py
+++ b/minfluxdbconvert/yaml.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import yaml
 import voluptuous as vol
-from minfluxdbconvert.util import string, boolean, ensure_list
+from minfluxdbconvert.util import string, ensure_list
 from minfluxdbconvert.const import (CONF_HOST, CONF_PORT, CONF_USER, CONF_PASSWORD,
                                     CONF_DBNAME, CONF_FILE, CONF_LOGGER, CONF_LEVEL,
                                     CONF_INFLUX, CONF_MINT, CONF_NETSUM, CONF_EXCLUDE,

--- a/minfluxdbconvert/yaml.py
+++ b/minfluxdbconvert/yaml.py
@@ -25,7 +25,9 @@ SCHEMA = vol.Schema({
     vol.Required(CONF_MINT): vol.Schema({
         vol.Optional(CONF_FILE): string,
         vol.Optional(CONF_DIR): string,
-        vol.Optional(CONF_ARCHIVE): boolean
+        vol.Optional(CONF_ARCHIVE): vol.Schema({
+            vol.Optional(CONF_DIR): string
+        })
     }),
     vol.Optional(CONF_LOGGER, default={CONF_FILE: '', CONF_LEVEL: 'INFO'}):
         vol.Schema({

--- a/minfluxdbconvert/yaml.py
+++ b/minfluxdbconvert/yaml.py
@@ -5,11 +5,12 @@ import sys
 import logging
 import yaml
 import voluptuous as vol
-from minfluxdbconvert.util import string, ensure_list
+from minfluxdbconvert.util import string, boolean, ensure_list
 from minfluxdbconvert.const import (CONF_HOST, CONF_PORT, CONF_USER, CONF_PASSWORD,
                                     CONF_DBNAME, CONF_FILE, CONF_LOGGER, CONF_LEVEL,
                                     CONF_INFLUX, CONF_MINT, CONF_NETSUM, CONF_EXCLUDE,
-                                    CONF_VENDOR, CONF_CATEGORY, CONF_ACCOUNT)
+                                    CONF_VENDOR, CONF_CATEGORY, CONF_ACCOUNT, CONF_DIR,
+                                    CONF_ARCHIVE)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +23,9 @@ SCHEMA = vol.Schema({
         vol.Required(CONF_DBNAME): string
     }),
     vol.Required(CONF_MINT): vol.Schema({
-        vol.Required(CONF_FILE): string
+        vol.Optional(CONF_FILE): string,
+        vol.Optional(CONF_DIR): string,
+        vol.Optional(CONF_ARCHIVE): boolean
     }),
     vol.Optional(CONF_LOGGER, default={CONF_FILE: '', CONF_LEVEL: 'INFO'}):
         vol.Schema({
@@ -49,8 +52,12 @@ def load_yaml(directory):
     with open(config_file, 'r') as yamlfile:
         cfg = yaml.load(yamlfile)
     try:
-        LOGGER.info(SCHEMA(cfg))
-        return SCHEMA(cfg)
+        LOGGER.debug(SCHEMA(cfg))
+        mint_props = [CONF_FILE, CONF_DIR]
+        if any(x in mint_props for x in cfg[CONF_MINT]):
+            return SCHEMA(cfg)
+        else:
+            raise vol.error.MultipleInvalid('Missing entry for mint')
     except vol.error.MultipleInvalid as err:
         LOGGER.error('Invalid configuration. %s', err)
         sys.exit(1)

--- a/tests/test_dbwrite.py
+++ b/tests/test_dbwrite.py
@@ -1,0 +1,76 @@
+"""Tests dbwrite functionality."""
+import unittest
+from unittest import mock
+from minfluxdbconvert import dbwrite as dbwrite
+
+class TestInfluxClient(unittest.TestCase):
+    """Tests InfluxClient class."""
+
+    def setUp(self):
+        """General initialization."""
+        self.config = {
+            'influxdb': {
+                'host': 'foo',
+                'port': 1234,
+                'dbname': 'foobar',
+                'user': 'bar',
+                'password': 'barfoo'
+            }
+        }
+
+    def tearDown(self):
+        """Tear down routine called after each test."""
+        self.config = dict()
+    
+    def test_init(self):
+        client = dbwrite.InfluxClient(self.config)
+        self.assertEqual(client.host, self.config['influxdb']['host'])
+        self.assertEqual(client.port, self.config['influxdb']['port'])
+        self.assertEqual(client.dbname, self.config['influxdb']['dbname'])
+        self.assertEqual(client.user, self.config['influxdb']['user'])
+        self.assertEqual(client.password, self.config['influxdb']['password'])
+
+    @mock.patch('minfluxdbconvert.dbwrite.InfluxDBClient.write_points')
+    def test_write_data(self, mock_influx):
+        mock_influx.return_value = None
+        client = dbwrite.InfluxClient(self.config)
+        client.write_data('')
+        self.assertEqual(mock_influx.call_count, 1)
+
+class TestInfluxDBWriter(unittest.TestCase):
+    """Class tests functionality of influxdb_write."""
+
+    def setUp(self):
+        """General initialization."""
+        self.config = {
+            'influxdb': {
+                'host': 'foo',
+                'port': 1234,
+                'dbname': 'foobar',
+                'user': 'bar',
+                'password': 'barfoo'
+            }
+        }
+        self.client = dbwrite.InfluxClient(self.config)
+
+    def tearDown(self):
+        """Tear down routine called after each test."""
+        self.config = dict()
+        self.client = None
+    
+    @mock.patch('minfluxdbconvert.dbwrite.json.dump')
+    @mock.patch('minfluxdbconvert.dbwrite.jsonify')
+    def test_db_skip(self, mock_json, mock_jsonify):
+        """Tests return of db_skip."""
+        mock_json.return_value = True
+        mock_jsonify.return_value = {}
+        self.assertTrue(dbwrite.influxdb_write(self.config, self.client, '', db_skip=True))
+
+    @mock.patch('minfluxdbconvert.dbwrite.jsonify')
+    @mock.patch('minfluxdbconvert.dbwrite.InfluxDBClient.write_points')
+    def test_normal_write(self, mock_influx, mock_jsonify):
+        """Tests a normal db write."""
+        mock_influx.return_value = None
+        mock_jsonify.return_value = dict()
+        self.assertTrue(dbwrite.influxdb_write(self.config, self.client, ''))
+        self.assertEqual(mock_influx.call_count, 1)  

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -5,7 +5,7 @@ from minfluxdbconvert import json as json
 
 class MockReader(object):
     """Class used to mock the reader module."""
-    def __init__(self, file):
+    def __init__(self, file, archive=False, archive_dir=None):
         self.headers = {
             'date': 0,
             'description': 1,
@@ -19,7 +19,7 @@ class MockReader(object):
         self.data = [['1/1/1970', 'foo', 'bar', 'credit', '3.50', 'foocat', 'foolabel', 'barnote'],
                      ['1/2/1970', 'oof', 'rab', 'debit', '1.25', 'tacoof', 'lebaloof', 'etonrab']]
 
-class TestYamlLoad(unittest.TestCase):
+class TestJsonify(unittest.TestCase):
     """Test jsonify functionality."""
     
     def setUp(self):
@@ -111,3 +111,47 @@ class TestYamlLoad(unittest.TestCase):
         self.assertEqual(len(body), 7)
         self.assertEqual(body[-1]['measurement'], 'net_sum')
         self.assertEqual(body[-1]['fields']['value'], 2.25)        
+
+    @mock.patch('minfluxdbconvert.json.reader')
+    def test_archive_single_file_custom_dir(self, mock_reader):
+        """Verify we don't cause errors in this mode."""
+        mock_reader.TransactionReader = MockReader
+        config = {
+            'mint': {
+                'file': '/foo.csv',
+                'archive': {
+                    'directory': '/tmp'
+                }
+            }
+        }
+        body = json.jsonify(config, '/foo.csv')
+        self.assertEqual(len(body), 7)
+
+    @mock.patch('minfluxdbconvert.json.reader')
+    def test_archive_dir_custom_dir(self, mock_reader):
+        """Verify we don't cause errors in this mode."""
+        mock_reader.TransactionReader = MockReader
+        config = {
+            'mint': {
+                'directory': '/foo',
+                'archive': {
+                    'directory': '/tmp'
+                }
+            }
+        }
+        body = json.jsonify(config, '/foo/bar.csv')
+        self.assertEqual(len(body), 7)
+
+    @mock.patch('minfluxdbconvert.json.reader')
+    def test_no_archive_dir(self, mock_reader):
+        """Verify we don't cause errors in this mode."""
+        mock_reader.TransactionReader = MockReader
+        config = {
+            'mint': {
+                'directory': '/foo',
+                'archive': {}
+            }
+        }
+        body = json.jsonify(config, '/foo/bar.csv')
+        self.assertEqual(len(body), 7)
+        

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,11 +34,10 @@ class TestMainModule(unittest.TestCase):
                 }
         }
         with mock.patch('sys.argv', test_args):
-            with self.assertRaises(SystemExit) as cm:
-                mock_fh = mock.mock_open()
-                with mock.patch('builtins.open', mock_fh, create=False):
-                    main.main()
-            self.assertEqual(cm.exception.code, None)        
+            mock_fh = mock.mock_open()
+            with mock.patch('builtins.open', mock_fh, create=False):
+                main.main()
+        self.assertEqual(mock_client.call_count, 1)      
 
     @mock.patch('minfluxdbconvert.__main__.glob.glob')
     def test_with_dir(self, mock_glob, mock_load_yaml, mock_client):
@@ -62,12 +61,10 @@ class TestMainModule(unittest.TestCase):
                 }
         }
         with mock.patch('sys.argv', test_args):
-            with self.assertRaises(SystemExit) as cm:
-                mock_fh = mock.mock_open()
-                with mock.patch('builtins.open', mock_fh, create=False):
-                    main.main()
-            self.assertEqual(mock_client.call_count, 3)
-            self.assertEqual(cm.exception.code, None)
+            mock_fh = mock.mock_open()
+            with mock.patch('builtins.open', mock_fh, create=False):
+                main.main()
+        self.assertEqual(mock_client.call_count, 3)
 
     @mock.patch('minfluxdbconvert.__main__.glob.glob')
     def test_bad_write(self, mock_glob, mock_load_yaml, mock_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,20 +3,22 @@ import unittest
 from unittest import mock
 from minfluxdbconvert import __main__ as main
 
+@mock.patch('minfluxdbconvert.__main__.dbwrite.influxdb_write')
+@mock.patch('minfluxdbconvert.__main__.yaml.load_yaml')
 class TestMainModule(unittest.TestCase):
        
-    def test_no_arguments(self):
+    def test_no_arguments(self, mock_load_data, mock_client):
+        mock_load_data.return_value = {}
+        mock_client.return_value = True
         with self.assertRaises(SystemExit) as cm:
             main.main()
         self.assertEqual(cm.exception.code, 2)
-
-    @mock.patch('minfluxdbconvert.__main__.json.dumps')
-    @mock.patch('minfluxdbconvert.__main__.jsonify')
-    @mock.patch('minfluxdbconvert.__main__.yaml.load_yaml')
-    def test_with_skip_db_push(self, mock_load_yaml, mock_jsonify, mock_json_dumps):
+        
+    def test_with_skip_db_push(self, mock_load_yaml, mock_client):
         test_args = ['mfdb', '--config=/tmp/fake/path', '--skip-push']
+        mock_client.return_value = True
         mock_load_yaml.return_value = {
-            'influx_db': {
+            'influxdb': {
                 'host': 'foo',
                 'port': 1234,
                 'user': 'foo',
@@ -31,12 +33,67 @@ class TestMainModule(unittest.TestCase):
                 'level': 'INFO'
                 }
         }
-        mock_jsonify.return_value = {'foo': 'bar'} 
-        mock_json_dumps.return_value = 'foobar'
         with mock.patch('sys.argv', test_args):
             with self.assertRaises(SystemExit) as cm:
                 mock_fh = mock.mock_open()
                 with mock.patch('builtins.open', mock_fh, create=False):
                     main.main()
             self.assertEqual(cm.exception.code, None)        
-        
+
+    @mock.patch('minfluxdbconvert.__main__.glob.glob')
+    def test_with_dir(self, mock_glob, mock_load_yaml, mock_client):
+        test_args = ['mfdb', '--config=/tmp/fake/path']
+        mock_glob.return_value = ['foo.csv', 'bar.csv', 'foobar.csv']
+        mock_client.return_value = True
+        mock_load_yaml.return_value = {
+            'influxdb': {
+                'host': 'foo',
+                'port': 1234,
+                'user': 'foo',
+                'password': 'bar',
+                'dbname': 'foobar'
+                },
+            'mint': {
+                'directory': '/foo/bar'
+                },
+            'logger': {
+                'file': '',
+                'level': 'INFO'
+                }
+        }
+        with mock.patch('sys.argv', test_args):
+            with self.assertRaises(SystemExit) as cm:
+                mock_fh = mock.mock_open()
+                with mock.patch('builtins.open', mock_fh, create=False):
+                    main.main()
+            self.assertEqual(mock_client.call_count, 3)
+            self.assertEqual(cm.exception.code, None)
+
+    @mock.patch('minfluxdbconvert.__main__.glob.glob')
+    def test_bad_write(self, mock_glob, mock_load_yaml, mock_client):
+        test_args = ['mfdb', '--config=/tmp/fake/path']
+        mock_client.return_value = False
+        mock_glob.return_value = ['foo.csv', 'bar.csv', 'foobar.csv']
+        mock_load_yaml.return_value = {
+            'influxdb': {
+                'host': 'foo',
+                'port': 1234,
+                'user': 'foo',
+                'password': 'bar',
+                'dbname': 'foobar'
+                },
+            'mint': {
+                'directory': '/foo/bar'
+                },
+            'logger': {
+                'file': '',
+                'level': 'INFO'
+                }
+        }
+        with mock.patch('sys.argv', test_args):
+            with self.assertRaises(SystemExit) as cm:
+                mock_fh = mock.mock_open()
+                with mock.patch('builtins.open', mock_fh, create=False):
+                    main.main()
+            self.assertEqual(mock_client.call_count, 1)
+            self.assertEqual(cm.exception.code, 1)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -3,10 +3,25 @@ import unittest
 from unittest import mock
 from minfluxdbconvert import reader as reader
 
+class MockPathLib(object):
+    def __init__(self, dir):
+        pass
+    @property
+    def parent(self):
+        return '/tmp'
+    @property
+    def name(self):
+        return 'bar.foo'
+    @property
+    def stem(self):
+        return '.foo'
+    def mkdir(self, parents=False, exist_ok=False):
+        return None
+
+@mock.patch('minfluxdbconvert.yaml.os.path.isfile')
 class TestTransactionReader(unittest.TestCase):
     """Test the TransactionReader class."""
 
-    @mock.patch('minfluxdbconvert.yaml.os.path.isfile')
     @mock.patch('minfluxdbconvert.reader.csv.reader')
     def test_read_csv(self, mock_csv_read, mock_is_file):
         mock_is_file.return_value = True
@@ -36,7 +51,6 @@ class TestTransactionReader(unittest.TestCase):
         for key in self.Reader.headers:
             self.assertTrue(self.Reader.headers[key] is not None)
 
-    @mock.patch('minfluxdbconvert.yaml.os.path.isfile')
     @mock.patch('minfluxdbconvert.reader.csv.reader')
     def test_extra_keys_in_data(self, mock_csv_read, mock_is_file):
         mock_is_file.return_value = True
@@ -68,8 +82,66 @@ class TestTransactionReader(unittest.TestCase):
         for key in self.Reader.headers:
             self.assertTrue(self.Reader.headers[key] is not None)
 
-    def test_file_not_exist(self):
+    def test_file_not_exist(self, mock_is_file):
+        mock_is_file.return_value = False
         with self.assertRaises(SystemExit) as cm:
             self.Reader = reader.TransactionReader('/tmp/fake')
         self.assertEqual(cm.exception.code, 1)
-            
+
+    @mock.patch('minfluxdbconvert.reader.TransactionReader.archive')
+    @mock.patch('minfluxdbconvert.reader.csv.reader')
+    def test_archive_entry(self, mock_csv_read, mock_archive, mock_is_file):
+        mock_archive.return_value = None
+        mock_is_file.return_value = True
+        mock_csv_read.return_value = [['Date',
+                                       'Category',
+                                       'Description',
+                                       'Amount',
+                                       'Transaction Type',
+                                       'Labels',
+                                       'Notes',
+                                       'Account Name'],
+                                       ['1/1/2017',
+                                        'foo',
+                                        'bar',
+                                        '3.50',
+                                        'debit',
+                                        'nolabel'
+                                        'nonote'
+                                        'foobar'
+                                       ]]
+        mock_fh = mock.mock_open()
+        with mock.patch('builtins.open', mock_fh, create=False):
+            self.Reader = reader.TransactionReader('/tmp/fake', archive=True)
+        self.assertEqual(mock_archive.call_count, 1)
+    
+    @mock.patch('minfluxdbconvert.reader.pathlib')
+    @mock.patch('minfluxdbconvert.reader.os.path.exists')
+    @mock.patch('minfluxdbconvert.reader.csv.reader')
+    def test_archive_exist_on_too_many_collisons(self, mock_csv_read, mock_exists, mock_pathlib, mock_is_file):
+        mock_pathlib.Path = MockPathLib
+        mock_is_file.return_value = True
+        mock_exists.return_value = True
+        mock_csv_read.return_value = [['Date',
+                                       'Category',
+                                       'Description',
+                                       'Amount',
+                                       'Transaction Type',
+                                       'Labels',
+                                       'Notes',
+                                       'Account Name'],
+                                       ['1/1/2017',
+                                        'foo',
+                                        'bar',
+                                        '3.50',
+                                        'debit',
+                                        'nolabel'
+                                        'nonote'
+                                        'foobar'
+                                       ]]
+        mock_fh = mock.mock_open()
+        with mock.patch('builtins.open', mock_fh, create=False):
+            with self.assertRaises(SystemExit) as cm:
+                self.Reader = reader.TransactionReader('/tmp/fake', archive=True)
+        self.assertEqual(cm.exception.code, 1)        
+        self.assertEqual(mock_exists.call_count, 257)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -6,8 +6,10 @@ from minfluxdbconvert import reader as reader
 class TestTransactionReader(unittest.TestCase):
     """Test the TransactionReader class."""
 
+    @mock.patch('minfluxdbconvert.yaml.os.path.isfile')
     @mock.patch('minfluxdbconvert.reader.csv.reader')
-    def test_read_csv(self, mock_csv_read):
+    def test_read_csv(self, mock_csv_read, mock_is_file):
+        mock_is_file.return_value = True
         mock_csv_read.return_value = [['Date',
                                        'Category',
                                        'Description',
@@ -34,8 +36,10 @@ class TestTransactionReader(unittest.TestCase):
         for key in self.Reader.headers:
             self.assertTrue(self.Reader.headers[key] is not None)
 
+    @mock.patch('minfluxdbconvert.yaml.os.path.isfile')
     @mock.patch('minfluxdbconvert.reader.csv.reader')
-    def test_extra_keys_in_data(self, mock_csv_read):
+    def test_extra_keys_in_data(self, mock_csv_read, mock_is_file):
+        mock_is_file.return_value = True
         mock_csv_read.return_value = [['Date',
                                        'Category',
                                        'Description',
@@ -63,5 +67,9 @@ class TestTransactionReader(unittest.TestCase):
         self.assertEqual(self.Reader.data, [mock_csv_read.return_value[1]])
         for key in self.Reader.headers:
             self.assertTrue(self.Reader.headers[key] is not None)
-        
+
+    def test_file_not_exist(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.Reader = reader.TransactionReader('/tmp/fake')
+        self.assertEqual(cm.exception.code, 1)
             


### PR DESCRIPTION
- [x] Implement archiving
- [x] Pass lint
- [ ] Test with real database

This PR implements the ability to have a directory of csv files that are read in and written to influxdb.  To use this, the following yaml is used:

```yaml
...
mint:
    directory: /path/to/csv/files
...
```

Support for archiving the files is next.  This ultimately paves the way for automatic directory management.